### PR TITLE
New chirp notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ This will open a CLI to run your commands. For example:
 
 This command will run the `all` method from the `Chirp` class, which lists all the Chirps from the database.
 
+## Emails
+
+If you are developing via Docker, you can see all the emails sent from the app by using Mailpit:
+
+http://localhost:8025/
+
+This email testing tool catches any emails coming from your application.
+
 ## Source
 
 The source of the instructions for starting the project is:

--- a/app/Events/ChirpCreated.php
+++ b/app/Events/ChirpCreated.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ChirpCreated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/app/Events/ChirpCreated.php
+++ b/app/Events/ChirpCreated.php
@@ -2,6 +2,7 @@
 
 namespace App\Events;
 
+use App\Models\Chirp;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PresenceChannel;
@@ -16,8 +17,10 @@ class ChirpCreated
 
     /**
      * Create a new event instance.
+     * 
+     * @param Chirp $chirp The object of the created Chirp.
      */
-    public function __construct()
+    public function __construct(public Chirp $chirp)
     {
         //
     }

--- a/app/Listeners/SendChirpCreatedNotifications.php
+++ b/app/Listeners/SendChirpCreatedNotifications.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\ChirpCreated;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+
+class SendChirpCreatedNotifications
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(ChirpCreated $event): void
+    {
+        //
+    }
+}

--- a/app/Listeners/SendChirpCreatedNotifications.php
+++ b/app/Listeners/SendChirpCreatedNotifications.php
@@ -3,10 +3,12 @@
 namespace App\Listeners;
 
 use App\Events\ChirpCreated;
+use App\Models\User;
+use App\Notifications\NewChirp;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
 
-class SendChirpCreatedNotifications
+class SendChirpCreatedNotifications implements ShouldQueue // The ShouldQueue interface tells Laravel that the listener should be run in a queue.
 {
     /**
      * Create the event listener.
@@ -18,9 +20,21 @@ class SendChirpCreatedNotifications
 
     /**
      * Handle the event.
+     * 
+     * @param ChirpCreated $event The event of the Chirp creation.
+     * @return void
      */
     public function handle(ChirpCreated $event): void
     {
-        //
+        // Gets all users except the creator of the new Chirp.
+        // Uses a cursor to avoid loading every user into memory at once.
+        $usersCursor = User::whereNot('id', $event->chirp->user_id)->cursor();
+
+        // Notify users about the new Chirp.
+        foreach ($usersCursor as $user) {
+            $user->notify(new NewChirp($event->chirp)); // TODO: Implement "following" feature.
+        }
+
+        // Note: In a production application you should add the ability for your users to unsubscribe from notifications like these.
     }
 }

--- a/app/Models/Chirp.php
+++ b/app/Models/Chirp.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Events\ChirpCreated;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -13,6 +14,10 @@ class Chirp extends Model
     // Mass assignment protection: only allow for "message" propery (https://laravel.com/docs/eloquent#mass-assignment).
     protected $fillable = [
         'message'
+    ];
+
+    protected $dispatchesEvents = [
+        'created' => ChirpCreated::class // Dispatch the ChirpCreated event when a new Chirp is created ( with the method create() which inserts it in the database ).
     ];
 
     public function user(): BelongsTo

--- a/app/Notifications/NewChirp.php
+++ b/app/Notifications/NewChirp.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class NewChirp extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+                    ->line('The introduction to the notification.')
+                    ->action('Notification Action', url('/'))
+                    ->line('Thank you for using our application!');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Notifications/NewChirp.php
+++ b/app/Notifications/NewChirp.php
@@ -2,7 +2,9 @@
 
 namespace App\Notifications;
 
+use App\Models\Chirp;
 use Illuminate\Bus\Queueable;
+use Illuminate\Support\Str;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -14,7 +16,7 @@ class NewChirp extends Notification
     /**
      * Create a new notification instance.
      */
-    public function __construct()
+    public function __construct(public Chirp $chirp)
     {
         //
     }
@@ -35,8 +37,10 @@ class NewChirp extends Notification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-                    ->line('The introduction to the notification.')
-                    ->action('Notification Action', url('/'))
+                    ->subject("New Chirp from {$this->chirp->user->name}")
+                    ->greeting("New Chirp from {$this->chirp->user->name}")
+                    ->line(Str::limit($this->chirp->message, 50))
+                    ->action('Go to Chirper', url('/'))
                     ->line('Thank you for using our application!');
     }
 

--- a/app/Notifications/NewChirp.php
+++ b/app/Notifications/NewChirp.php
@@ -15,6 +15,8 @@ class NewChirp extends Notification
 
     /**
      * Create a new notification instance.
+     * 
+     * @param Chirp $chirp The Chirp to notify about it's creation.
      */
     public function __construct(public Chirp $chirp)
     {

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Events\ChirpCreated;
+use App\Listeners\SendChirpCreatedNotifications;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -15,6 +17,11 @@ class EventServiceProvider extends ServiceProvider
      * @var array<class-string, array<int, class-string>>
      */
     protected $listen = [
+        // The SendChirpCreatedNotifications event listener will be invoked when the ChirpCreated event is dispatched.
+        ChirpCreated::class => [
+            SendChirpCreatedNotifications::class
+        ],
+
         Registered::class => [
             SendEmailVerificationNotification::class,
         ],


### PR DESCRIPTION
When a new Chirp is created, send an email notification to all the users but the creator of the Chirp. It's achieved through a basic usage of events and listeners.

Also, new documentation in the readme file on how to test the emails sent from the app.